### PR TITLE
Add Support for Movie Genres

### DIFF
--- a/movie_night/genrecollector.py
+++ b/movie_night/genrecollector.py
@@ -1,0 +1,48 @@
+import urllib
+import aiohttp
+import time
+import asyncio
+
+async def get_genre(movie_title, session):
+    search_string = "+".join(movie_title.split())
+    url = f'https://www.google.com/search?q={search_string}'
+    print(url)
+    async with session.get(url) as resp:
+        html = await resp.text()
+        parts = html.split("&#8231;")
+        if len(parts) < 3:
+            return "Unknown"
+        
+        return parts[1].strip()
+            
+async def get_genres(movie_list):
+    REQ_HDRS = {
+        'User-Agent': 'python-requests/2.25.1',
+        'Accept-Encoding': 'gzip, deflate',
+        'Accept': '*/*',
+        'Connection': 'keep-alive'
+    }
+    tasks = []
+    async with aiohttp.ClientSession(headers=REQ_HDRS) as session:
+        for movie in movie_list:
+            tasks.append(get_genre(movie, session))
+        
+        genres = await asyncio.gather(*tasks)
+        return genres
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+            
+            
+            
+            
+            
+            

--- a/movie_night/genrecollector.py
+++ b/movie_night/genrecollector.py
@@ -1,14 +1,14 @@
-import urllib
 import aiohttp
-import time
 import asyncio
 
+# Grab the movie genre in a slightly painful way
 async def get_genre(movie_title, session):
     search_string = "+".join(movie_title.split())
     url = f'https://www.google.com/search?q={search_string}'
-    print(url)
     async with session.get(url) as resp:
         html = await resp.text()
+        # this represents the dot symbol that appears on either
+        # side of the genre on a google knowledge panel.
         parts = html.split("&#8231;")
         if len(parts) < 3:
             return "Unknown"

--- a/movie_night/movie_bot.py
+++ b/movie_night/movie_bot.py
@@ -1,7 +1,4 @@
 import discord
-import asyncio
-import aiohttp
-import time
 
 from fuzzysearch import find_near_matches
 from redbot.core import commands

--- a/movie_night/movie_bot.py
+++ b/movie_night/movie_bot.py
@@ -1,10 +1,15 @@
 import discord
+import asyncio
+import aiohttp
+import time
+
 from fuzzysearch import find_near_matches
 from redbot.core import commands
 from redbot.core import Config
 from redbot.core import checks
 
 from .voteinfo import VoteInfo, VoteException
+from .genrecollector import get_genres
 
 class MovieNightCog(commands.Cog):
     """Custom Movie Night Cog"""
@@ -134,16 +139,20 @@ class MovieNightCog(commands.Cog):
                 await ctx.send("Maximum number of suggestions has already been reached!")
                 return
             
+            genre = (await get_genres([movie_title]))[0]
             if movie_title in suggestions:
                 await ctx.send(f"\"**{movie_title}**\" is already in the list!")
             else:
                 suggestions.append(movie_title)
-                await ctx.send(f"\"**{movie_title}**\" has been added to the list of movie suggestions.")
+                if genre != "Unknown":
+                    await ctx.send(f"\"**{movie_title}** ({genre})\" has been added to the list of movie suggestions.")
+                else:
+                    await ctx.send(f"\"**{movie_title}**\" has been added to the list of movie suggestions.\nUnfortunately, I don't know the genre of {movie_title}! Feel free to help me out with: `{ctx.prefix}genre \"{movie_title}\" <genre>`.")
             
             # If a vote is on-going, add the suggestion to the vote list
             vinfo = await self.get_vote_info(ctx.guild.id)
             if vinfo.is_voting_enabled():
-                await vinfo.add_voting_option(movie_title)
+                await vinfo.add_voting_option(movie_title, genre)
     
     @commands.command(name="unsuggest")
     async def _cmd_del_suggestion(self, ctx: commands.Context, suggestion, *args):
@@ -204,6 +213,44 @@ class MovieNightCog(commands.Cog):
         
         await ctx.send(embed=em)
     
+    @commands.command(name="genre")
+    async def _cmd_update_genre(self, ctx: commands.Context, movie, *args):
+        """Updates the genre associated with a movie. eg. [p]genre 1 Romance OR [p]genre \"Shrek 2\" Horror/Thriller"""
+        vinfo = await self.get_vote_info(ctx.guild.id)
+        
+        genre = " ".join(args)
+        
+        movie_index = None
+        
+        if self.represents_int(movie):
+            # Check if it's an integer or a movie title (prefer integer)
+            movie_index = int(movie)
+            
+        if movie_index is not None:
+            # Index genre change
+            movie_index = movie_index - 1
+            
+            async with self.config.guild(ctx.guild).suggestions() as suggestions:
+                if movie_index < 0 or movie_index >= len(suggestions):
+                    await ctx.send(f"That isn't a valid index, sorry! Please check the current list with: `{ctx.prefix}suggestions`.")
+                else:
+                    movie_title = suggestions[movie_index]
+                    await vinfo.update_movie_genre(movie_title, genre)
+                    await ctx.send(f"The genre of \"**{movie_title}**\" has been changed to \"{genre}\".")
+        else:
+            # Fuzzy genre change
+            async with self.config.guild(ctx.guild).suggestions() as suggestions:
+                search_result = self.fuzzy_suggestion_search(movie, suggestions)
+                
+                if search_result is not None:
+                    try:
+                        await vinfo.update_movie_genre(search_result, genre)
+                        await ctx.send(f"The genre of \"**{search_result}**\" has been changed to \"{genre}\".")
+                    except ValueError:
+                        await ctx.send(f"Error when updating matched movie title! `{movie} -> {search_result}`.")
+                else:
+                    await ctx.send(f"Could not find that movie title!")
+                
     
     """Admin Commands"""
     

--- a/movie_night/voteinfo.py
+++ b/movie_night/voteinfo.py
@@ -4,6 +4,8 @@ import random
 from typing import List, Tuple, Dict, Optional
 from functools import cmp_to_key
 
+from .genrecollector import get_genres
+
 alphabet = 'a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z'.split(',')
 alphaset = set(alphabet)
 alpha_to_num = {alphabet[i]: i for i in range(len(alphabet))}
@@ -21,6 +23,7 @@ class VoteInfo:
         self._enabled = False
         self._msg = None
         self._choices = []
+        self._genres = {}
         self._movie_votes = {}
         self._user_votes  = {}
         
@@ -37,6 +40,7 @@ class VoteInfo:
         await self._clear_vote()
         
         self._choices = choices
+        await self._check_for_genres()
         self._create_vote_structures()
         
         await self.update_vote_message(ctx)
@@ -127,9 +131,10 @@ class VoteInfo:
             
             entry_title = entry['title']
             alpha = entry['alpha']
+            genre = self._genres[entry_title]
             icon = f":regional_indicator_{alpha}:"
             
-            msg.append(f"{bar_fill}{bar_empty}{icon} - **{entry_title}** ({num_votes})")
+            msg.append(f"{bar_fill}{bar_empty}{icon} - **{entry_title}** · *{genre}* · ({num_votes})")
         
         content = title + border + "\n" + "\n".join(msg) + "\n" + border
         
@@ -153,12 +158,15 @@ class VoteInfo:
             # TODO: log this
             raise VoteException("Unknown error occurred!")
     
-    async def add_voting_option(self, movie_title:str) -> None:
+    async def add_voting_option(self, movie_title:str, movie_genre:str) -> None:
         """Add a new voting option to the vote, while vote is happening"""
         index = len(self._choices)
         
         # Add to the list of choices
         self._choices.append(movie_title)
+        
+        # Store the genre
+        self._genres[movie_title] = movie_genre
         
         # Create an entry in the voting structures
         self._add_vote_structure(movie_title, index)
@@ -200,6 +208,10 @@ class VoteInfo:
     
     def check_msg_id(self, id:int) -> bool:
         return self._msg is not None and id == self._msg.id
+        
+    async def update_movie_genre(self, movie_title, movie_genre):
+        self._genres[movie_title] = movie_genre
+        await self.update_vote_message(None)
     
     """ Private methods """
     
@@ -228,6 +240,7 @@ class VoteInfo:
             
             # Create vote structures with the given choices
             self._choices = suggestions
+            await self._check_for_genres()
             self._create_vote_structures()
             
             # Get the reactions (votes)
@@ -291,6 +304,19 @@ class VoteInfo:
     def _remove_vote(self, title:str, uid:str) -> None:
         self._user_votes[uid].remove(title)
         self._movie_votes[title]['votes'].remove(uid)
+    
+    async def _check_for_genres(self):
+        # determine which movies require a genre added
+        needs_genre = []
+        for movie in self._choices:
+            if movie not in self._genres or self._genres[movie] is None:
+                needs_genre.append(movie)
+        
+        if len(needs_genre) > 0:
+            # now get the genres for these movies
+            new_genres = await get_genres(needs_genre)
+            for i in range(0, len(needs_genre)):
+                self._genres[needs_genre[i]] = new_genres[i]
     
     @staticmethod
     def gen_alpha_emoji(offset:int) -> str:


### PR DESCRIPTION
Have movies tagged with their genre when they are added.
The genre of a movie is currently determined by scraping a Google search for the movie. This is painful, but currently seems the only way to access useful genre information. The function can easily be swapped out at a later time if a better way is found.

A movie's genre can also be edited with the '[p]genre' command, allowing unknown or incorrect genres to be updated.

This works on legacy votes as well -- a vote that has started with genre-less movies will have their genres asynchronously gathered and updated, so the list does not need to be recreated.